### PR TITLE
Fix: Build breaks when styles/scripts sources are empty

### DIFF
--- a/dist/gulp.config.mjs
+++ b/dist/gulp.config.mjs
@@ -1,7 +1,7 @@
 /**
  * Gulp Configuration.
  *
- * This config file is for use during the development of drupal-gulp.
+ * @see https://github.com/jigarius/drupal-gulp/blob/1.x/dist/gulp.config.mjs
  */
 
 import { ConfigBuilder } from 'drupal-gulp';

--- a/dist/gulpfile.mjs
+++ b/dist/gulpfile.mjs
@@ -68,7 +68,11 @@ gulp.task('clean:scripts', cleanScripts);
 /**
  * Build styles.
  */
-function buildStyles() {
+function buildStyles(callback) {
+  if (config.styleSources.length === 0) {
+    return callback();
+  }
+
   const sass = gulpSass(dartSass);
   return gulp
     .src(config.styleSources, {
@@ -116,7 +120,11 @@ gulp.task('build:styles', buildStyles);
 /**
  * Build scripts.
  */
-function buildScripts() {
+function buildScripts(callback) {
+  if (config.scriptSources.length === 0) {
+    return callback();
+  }
+
   return gulp
     .src(config.scriptSources, {
       allowEmpty: true,
@@ -154,7 +162,11 @@ gulp.task('build:scripts', buildScripts);
 /**
  * Lint styles.
  */
-function lintStyles() {
+function lintStyles(callback) {
+  if (config.styleSources.length === 0) {
+    return callback();
+  }
+
   return gulp
     .src(config.styleSources, {
       allowEmpty: true,
@@ -193,7 +205,11 @@ gulp.task('watch:styles', watchStyles);
 /**
  * Lint scripts.
  */
-function lintScripts() {
+function lintScripts(callback) {
+  if (config.scriptSources.length === 0) {
+    return callback();
+  }
+
   return gulp
     .src(config.scriptSources, {
       allowEmpty: true,


### PR DESCRIPTION
When no scripts or no styles are provided in the config, the build breaks. After these changes, builds work even if no styles or scripts are configured.